### PR TITLE
Fix two typos Genevieve found in debugging principles

### DIFF
--- a/debugging_principles.ipynb
+++ b/debugging_principles.ipynb
@@ -77,7 +77,7 @@
    ],
    "source": [
     "def myfunc(a, b):\n",
-    "    return a**b\n",
+    "    return b**a\n",
     "\n",
     "\n",
     "a = 2\n",
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That's clearly not 25 and we can see why - we didn't put the inputs in the correct order, so we computed $2^5$ instead of $5^2$. In this case, however, the code *runs* fine, it just doesn't run *correctly*. These types of errors can be far more pernicious than syntax errors since the code doesn't throw an immediate fit. This assumes that the underlying logic of the algorithm is correct, but that there's a typo in the code or an issue with some of the data structures or packages that were used. Consider the following example that's a bit trickier. Let's say we wanted to calculate both the sum of the values in a list ($\\sum_{i=1}^{N} x_i$) and the sum of the squares in the list ($\\sum_{i=1}^{N} x_i$). And as input we give it $[1,2,3]$. What we would want to see as output are:\n",
+    "That's clearly not 25 and we can see why - we didn't put the inputs in the correct order, so we computed $2^5$ instead of $5^2$. In this case, however, the code *runs* fine, it just doesn't run *correctly*. These types of errors can be far more pernicious than syntax errors since the code doesn't throw an immediate fit. This assumes that the underlying logic of the algorithm is correct, but that there's a typo in the code or an issue with some of the data structures or packages that were used. Consider the following example that's a bit trickier. Let's say we wanted to calculate both the sum of the values in a list ($\\sum_{i=1}^{N} x_i$) and the sum of the squares in the list ($\\sum_{i=1}^{N} x_i^2$). And as input we give it $[1,2,3]$. What we would want to see as output are:\n",
     "$$\\sum_{i=1}^{N} x_i = 1 + 2 + 3 = 6$$\n",
     "\n",
     "and\n",


### PR DESCRIPTION
a * * b was listed as backwards and the bug to fix, but was correct order, so we made it b * * a (the bug)
You were also missing a ^2 in where you said the list was squared.